### PR TITLE
Patch the code to automatically figure out the processor name define.

### DIFF
--- a/cubemx2qbs.py
+++ b/cubemx2qbs.py
@@ -100,7 +100,6 @@ def parsePackage(pack) :
 						for f in files.findall('file') :
 							if ('condition' in f.attrib and f.attrib['condition'] == 'GCC Toolchain') :
 								result = re.match( r'.*startup_(.*)\.s', f.attrib['name'], re.M|re.I)
-								print result.group(1).upper()
 								defineProcessorName = result.group(1).upper().replace('X', 'x')
 
 	result = "import qbs\n\n"


### PR DESCRIPTION
The proper CPU name define could be figured out from the following tag's filename:

`<file category="sourceAsm" condition="GCC Toolchain"
			# name="Drivers\CMSIS\Device\ST\STM32F1xx\Source\Templates\gcc\startup_**stm32f103xb**.s"/>`

Fixes issue mentioned in the issue #2 