### PR TITLE
Prevent duplicate files

### DIFF
--- a/cubemx2qbs.py
+++ b/cubemx2qbs.py
@@ -43,6 +43,7 @@ Linker_Flags = [ "-Xlinker",
 project_name = ""
 processor_name = ""
 includepaths = []
+filesWritten = []
 
 ################################################################################
 
@@ -184,6 +185,11 @@ def parseFiles(files) :
 				continue
 			cur_file = child.attrib['name'].replace('\\', '/')
 			dir_name = os.path.dirname(cur_file)
+			if cur_file in filesWritten :
+				# if the current file was exported already skip it
+				# to prevent the qbs from claiming about duplicated files
+				continue 
+			filesWritten.append(cur_file)
 			if cur_file[-2:] == ".h" and includepaths.count(dir_name) == 0 :
 				includepaths.append(dir_name)
 			result.append(cur_file)

--- a/cubemx2qbs.py
+++ b/cubemx2qbs.py
@@ -100,7 +100,6 @@ def parsePackage(pack) :
 						for f in files.findall('file') :
 							if ('condition' in f.attrib and f.attrib['condition'] == 'GCC Toolchain') :
 								result = re.match( r'.*startup_(.*)\.s', f.attrib['name'], re.M|re.I)
-								print result.group(1).upper()
 								defineProcessorName = result.group(1).upper().replace('X', 'x')
 
 	result = "import qbs\n\n"
@@ -181,7 +180,7 @@ def parseFiles(files) :
 	result = []
 	for child in files :
 		if child.tag == 'file' :
-			if child.attrib.has_key('condition') and child.attrib['condition'] != 'GCC Toolchain' :
+			if child.attrib.has_key('condition') and (child.attrib['condition'] != 'GCC Toolchain' and child.attrib['condition'] != '') :
 				continue
 			cur_file = child.attrib['name'].replace('\\', '/')
 			dir_name = os.path.dirname(cur_file)


### PR DESCRIPTION
The CubeMX 4.21.0 generated the following file for me:
https://gist.github.com/martonmiklos/834afd4e8512e36e8636d6e32acbf953

The Drivers\STM32F1xx_HAL_Driver\Src\stm32f1xx_hal.{.h,.c} appears twice in the gpdsc file.
This patch eliminates the possibility of including files twice. 